### PR TITLE
Multiple Scala version support for Scala IDE 4.0. Fix #239

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -21,7 +21,8 @@ object Build extends Build {
     settings = commonSettings ++ Seq(
       libraryDependencies ++= Seq(
        "org.scalaz" %% "scalaz-core"   % "7.1.0",
-       "org.scalaz" %% "scalaz-effect" % "7.1.0")
+       "org.scalaz" %% "scalaz-effect" % "7.1.0",
+       "org.scalatest" %% "scalatest" % "2.2.1" % "test")
     )
   )
 

--- a/sbteclipse-core/src/main/scala/com/typesafe/sbteclipse/util/ScalaVersion.scala
+++ b/sbteclipse-core/src/main/scala/com/typesafe/sbteclipse/util/ScalaVersion.scala
@@ -1,0 +1,21 @@
+package com.typesafe.sbteclipse.util
+
+import util.control.Exception
+
+case class ScalaVersion(era: Int, major: Int, minor: Int, qualifier: Option[String]) {
+  def isScala210: Boolean = era == 2 && major == 10
+}
+
+object ScalaVersion {
+  private val versionRegex = """(\d+)\.(\d+)\.(\d+)(-\S+)?""".r
+
+  def parse(version: String): Option[ScalaVersion] = version match {
+    case versionRegex(era, major, minor, qualifier) =>
+      // if qualifier is not null, drop the leading "-"
+      val qual = Option(qualifier).map(_.tail)
+      Exception.failing(classOf[NumberFormatException]) {
+        Some(ScalaVersion(era.toInt, major.toInt, minor.toInt, qual))
+      }
+    case _ => None
+  }
+}

--- a/sbteclipse-core/src/test/scala/com/typesafe/sbteclipse/util/ScalaVersionSpec.scala
+++ b/sbteclipse-core/src/test/scala/com/typesafe/sbteclipse/util/ScalaVersionSpec.scala
@@ -1,0 +1,32 @@
+package com.typesafe.sbteclipse.util
+
+import org.scalatest.WordSpec
+import org.scalatest.Matchers
+
+class ScalaVersionSpec extends WordSpec with Matchers {
+  "ScalaVersion" should {
+    """parse Scala version "2.10.0"""" in {
+      ScalaVersion.parse("2.10.0") shouldBe Some(ScalaVersion(2, 10, 0, None))
+    }
+
+    """parse Scala version "2.10.0-SNAPSHOT"""" in {
+      ScalaVersion.parse("2.10.0-SNAPSHOT") shouldBe Some(ScalaVersion(2, 10, 0, Some("SNAPSHOT")))
+    }
+
+    """parse Scala version "2.10.0-RC10"""" in {
+      ScalaVersion.parse("2.10.0-RC10") shouldBe Some(ScalaVersion(2, 10, 0, Some("RC10")))
+    }
+
+    """parse Scala version "2.10.0-M1"""" in {
+      ScalaVersion.parse("2.10.0-M1") shouldBe Some(ScalaVersion(2, 10, 0, Some("M1")))
+    }
+
+    """parse Scala version "2.10.0-51e77037f2adc4ffa7421aa36803a5874292b70d"""" in {
+      ScalaVersion.parse("2.10.0-51e77037f2adc4ffa7421aa36803a5874292b70d") shouldBe Some(ScalaVersion(2, 10, 0, Some("51e77037f2adc4ffa7421aa36803a5874292b70d")))
+    }
+
+    """fail to parse "2.10"""" in {
+      ScalaVersion.parse("2.10") shouldBe None
+    }
+  }
+}


### PR DESCRIPTION
The latest Scala IDE 4.0 supports both Scala 2.10 and 2.11 projects. To
correctly export a Scala 2.10 project, a few properties need to be properly set.

This commit assumes that sbteclipse only needs to support Scala IDE 4.0+, as I
haven't tested if the additional settings could cause issues when importing a
Scala 2.10 project in Scala IDE 3.x.

I've manually tested that running the `eclipse` command on both the sbteclipse
project itself, and the playframework project work as expected.

review by @huitseeker or  @dragos