### PR TITLE
Set Java file type to UTF-8 by default

### DIFF
--- a/sbteclipse-core/src/main/scala/com/typesafe/sbteclipse/core/Eclipse.scala
+++ b/sbteclipse-core/src/main/scala/com/typesafe/sbteclipse/core/Eclipse.scala
@@ -226,6 +226,7 @@ private object Eclipse extends EclipseSDTConfig {
       )
       _ <- saveXml(baseDirectory / ".project", new RuleTransformer(projectTransformers: _*)(projectXml(name, builderAndNatures, linkedSrcDirectories)))
       _ <- saveXml(baseDirectory / ".classpath", new RuleTransformer(classpathTransformers: _*)(cp))
+      _ <- saveProperties(baseDirectory / ".settings" / "org.eclipse.core.resources.prefs", Seq(("encoding/<project>" -> "UTF-8")))
       _ <- saveProperties(baseDirectory / ".settings" / "org.scala-ide.sdt.core.prefs", scalacOptions ++: compileOrder.map { order => Seq(("compileorder" -> order)) }.getOrElse(Nil))
     } yield n
   }

--- a/sbteclipse-plugin/src/sbt-test/sbteclipse/01-structure/test
+++ b/sbteclipse-plugin/src/sbt-test/sbteclipse/01-structure/test
@@ -1,7 +1,7 @@
 # Default settings (skip-parents=true)
 $ exec find . -path "*.classpath*" -delete
 $ exec find . -path "*.project*" -delete
-$ exec find . -path "*/.settings*" -delete
+$ exec find . -path "*.settings*" -delete
 $ exec find . -path "*/touch-pre-task" -delete
 > eclipse
 $ absent .classpath
@@ -14,9 +14,11 @@ $ absent sub/.settings
 $ absent sub/touch-pre-task
 $ exists sub/suba/.classpath
 $ exists sub/suba/.project
-$ absent sub/suba/.settings
+$ exists sub/suba/.settings
+$ exists sub/suba/.settings/org.eclipse.core.resources.prefs
 $ exists sub/subb/.classpath
 $ exists sub/subb/.project
+$ exists sub/subb/.settings/org.eclipse.core.resources.prefs
 $ exists sub/subb/.settings/org.scala-ide.sdt.core.prefs
 $ exists sub/subb/touch-pre-task
 $ absent sub/subc/.classpath
@@ -31,17 +33,20 @@ $ exec find . -path "*/.settings*" -delete
 > eclipse skip-parents=false
 $ exists .classpath
 $ exists .project
-$ absent .settings
+$ exists .settings
 $ absent touch-pre-task
 $ exists sub/.classpath
 $ exists sub/.project
-$ absent sub/.settings
+$ exists sub/.settings
+$ exists sub/.settings/org.eclipse.core.resources.prefs
 $ absent sub/touch-pre-task
 $ exists sub/suba/.classpath
 $ exists sub/suba/.project
-$ absent sub/suba/.settings
+$ exists sub/suba/.settings
+$ exists sub/suba/.settings/org.eclipse.core.resources.prefs
 $ exists sub/subb/.classpath
 $ exists sub/subb/.project
+$ exists sub/subb/.settings/org.eclipse.core.resources.prefs
 $ exists sub/subb/.settings/org.scala-ide.sdt.core.prefs
 $ exists sub/subb/touch-pre-task
 $ absent sub/subc/.classpath

--- a/sbteclipse-plugin/src/sbt-test/sbteclipse/02-contents/build.sbt
+++ b/sbteclipse-plugin/src/sbt-test/sbteclipse/02-contents/build.sbt
@@ -207,7 +207,19 @@ TaskKey[Unit]("verify-classpath-xml-subc") <<= baseDirectory map { dir =>
     error("""Expected .project of subc project to contain <foo bar="baz"/>!""")
 }
 
-TaskKey[Unit]("verify-settings") <<= baseDirectory map { dir =>
+TaskKey[Unit]("verify-java-settings") <<= baseDirectory map { dir =>
+  val settings = {
+    val p = new Properties 
+    p.load(new FileInputStream(dir / "sub/subb/.settings/org.eclipse.core.resources.prefs"))
+    p.asScala.toMap
+  }
+  val expected = Map(
+    "encoding/<project>" -> "UTF-8"
+  ) 
+  if (settings != expected) error("Expected settings to be '%s', but was '%s'!".format(expected, settings))
+}
+
+TaskKey[Unit]("verify-scala-settings") <<= baseDirectory map { dir =>
   val settings = {
     val p = new Properties 
     p.load(new FileInputStream(dir / "sub/subb/.settings/org.scala-ide.sdt.core.prefs"))

--- a/sbteclipse-plugin/src/sbt-test/sbteclipse/02-contents/test
+++ b/sbteclipse-plugin/src/sbt-test/sbteclipse/02-contents/test
@@ -12,4 +12,5 @@ $ mkdir target/scala-2.9.1/src_managed/main
 > verify-classpath-xml-suba
 > verify-classpath-xml-subb
 > verify-classpath-xml-subc
-> verify-settings
+> verify-java-settings
+> verify-scala-settings


### PR DESCRIPTION
We already do this today for Scala IDE users by setting `scala.compiler.additionalParams=-encoding utf8`. It'd be nice to do this for users that don't use Scala IDE as well

Also, Play does this today and I'd like to upstream all of Play's improvements. This change is fairly well-tested given how long that Play's been doing it