### PR TITLE
Don't take the Scala library off the classpath unless using Scala IDE or otherwise requested

### DIFF
--- a/sbteclipse-core/src/main/scala/com/typesafe/sbteclipse/core/EclipsePlugin.scala
+++ b/sbteclipse-core/src/main/scala/com/typesafe/sbteclipse/core/EclipsePlugin.scala
@@ -204,16 +204,16 @@ trait EclipsePlugin {
 
   object EclipseCreateSrc extends Enumeration {
 
-    @deprecated("Always enabled", "3.1.0")
+    @deprecated("Always enabled", "4.0.0")
     val Unmanaged = Value
 
-    @deprecated("Use ManagedSrc and ManagedResources", "3.1.0")
+    @deprecated("Use ManagedSrc and ManagedResources", "4.0.0")
     val Managed = Value
 
-    @deprecated("Always enabled", "3.1.0")
+    @deprecated("Always enabled", "4.0.0")
     val Source = Value
 
-    @deprecated("Always enabled", "3.1.0")
+    @deprecated("Always enabled", "4.0.0")
     val Resource = Value
 
     val ManagedSrc = Value
@@ -222,13 +222,16 @@ trait EclipsePlugin {
 
     val Default = ValueSet(ManagedSrc, ManagedResources)
 
-    @deprecated("Does nothing. Uses default values", "3.1.0")
+    @deprecated("Does nothing. Uses default values", "4.0.0")
     val All = Default
   }
 
   object EclipseProjectFlavor extends Enumeration {
 
-    val Scala = Value
+    val ScalaIDE = Value
+
+    @deprecated("Use ScalaIDE", "4.0.0")
+    val Scala = ScalaIDE
 
     val Java = Value
   }

--- a/sbteclipse-plugin/src/sbt-test/sbteclipse/02-contents/project/Build.scala
+++ b/sbteclipse-plugin/src/sbt-test/sbteclipse/02-contents/project/Build.scala
@@ -105,7 +105,7 @@ object Build extends Build {
     "scala",
     new File("scala"),
     settings = Project.defaultSettings ++ Seq(
-      EclipseKeys.projectFlavor := EclipseProjectFlavor.Scala
+      EclipseKeys.projectFlavor := EclipseProjectFlavor.ScalaIDE
     )
   )
 


### PR DESCRIPTION
There's a few changes here:
* Removed a bunch of places `WithBundledScalaContainers` was unused
* Renamed `ProjectFlavors.Scala` to the much more accurate and clearer `ProjectFlavors.ScalaIDE`. This variable only controls whether our project will be generated for Scala IDE (all it does is put the org.scala-ide builders and natures on the project)
* Changed the default of `WithBundledScalaContainers` to be whether we're using `ProjectFlavors.ScalaIDE`. Previously the value was true, which would remove the Scala library from the classpath even when not using Scala IDE. Because of this, Play has to do an [ugly hack](https://github.com/benmccann/playframework/blob/ca664a7d108c24e08e86fb815e7104fcf326bf6e/framework/src/sbt-plugin/src/main/scala/PlayEclipse.scala#L56) of looking at the project classpath, finding the jar, and then using a transformer to add it back to the Eclipse classpath after sbteclipse has already added and then removed it. I [fixed the ugly hack](https://github.com/playframework/playframework/commit/f50b943901b6a5380a223d4930e2b3f746800194) by correcting the default value, but it'd be nicer still to correct the default value here for all users instead of how I did it just for Play users.

The wiki will need to be updated to reflect the `Scala` to `ScalaIDE` rename and new default value of `WithBundledScalaContainers`. It's currently wrong to begin with regarding the default value of `WithBundledScalaContainers`