### PR TITLE
Multiple Scala version support for Scala IDE 4.0. Fix #239

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@ language: scala
 scala:
   - 2.10.3
 jdk:
-   - oraclejdk7
+   - oraclejdk8
    - openjdk7
 cache:
   directories:
   - $HOME/.ivy2
 script:
-  - sbt scripted
+  - sbt ++$TRAVIS_SCALA_VERSION -jvm-opts .travis/jvmopts scripted

--- a/.travis/jvmopts
+++ b/.travis/jvmopts
@@ -1,0 +1,5 @@
+-Dfile.encoding=UTF8
+-Xms3072M
+-Xmx3072M
+-XX:MaxPermSize=3072M
+-XX:+CMSClassUnloadingEnabled

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -16,8 +16,9 @@ object Build extends Build {
     file("."),
     settings = commonSettings ++ Seq(
       libraryDependencies ++= Seq(
-        "org.scalaz" %% "scalaz-core"   % "7.1.0",
-        "org.scalaz" %% "scalaz-effect" % "7.1.0")
+        "org.scalaz"    %% "scalaz-core"   % "7.1.0",
+        "org.scalaz"    %% "scalaz-effect" % "7.1.0",
+        "org.scalatest" %% "scalatest"     % "2.2.1" % "test")
     )
   )
 

--- a/src/main/scala/com/typesafe/sbteclipse/core/util/ScalaVersion.scala
+++ b/src/main/scala/com/typesafe/sbteclipse/core/util/ScalaVersion.scala
@@ -1,0 +1,39 @@
+package com.typesafe.sbteclipse.core.util
+
+import util.control.Exception
+
+private[core] trait ScalaVersion {
+  def settingsFrom(currentSettings: Map[String, String]): Map[String, String]
+}
+
+private[core] case object NoScalaVersion extends ScalaVersion {
+  def settingsFrom(currentSettings: Map[String, String]): Map[String, String] = currentSettings
+}
+
+private[core] object ScalaVersion {
+  private val versionRegex = """(\d+)\.(\d+)\.(\d+)(-\S+)?""".r
+
+  def parse(version: String): ScalaVersion = version match {
+    case versionRegex(era, major, minor, qualifier) =>
+      // if qualifier exists (i.e., is not null), drop the leading '-'
+      val qual = Option(qualifier).map(_.tail)
+      Exception.failAsValue(classOf[NumberFormatException])(NoScalaVersion) {
+        FullScalaVersion(era.toInt, major.toInt, minor.toInt, qual)
+      }
+    case _ => NoScalaVersion
+  }
+
+  private[core] case class FullScalaVersion(era: Int, major: Int, minor: Int, qualifier: Option[String]) extends ScalaVersion {
+    private def isScala210: Boolean = era == 2 && major == 10
+
+    def settingsFrom(currentSettings: Map[String, String]): Map[String, String] = {
+      // If `version` is Scala 2.10, returns the `settings` with the required additional parameters for enabling the Scala 2.10 support in Scala IDE 4.0+.
+      // Otherwise, returns `settings` unchanged.
+      if (isScala210) {
+        val key = "scala.compiler.additionalParams"
+        val newValue = (currentSettings.getOrElse(key, "") + " -Xsource:2.10 -Ymacro-expand:none").trim()
+        currentSettings + (key -> newValue) + ("scala.compiler.installation" -> "2.10")
+      } else currentSettings
+    }
+  }
+}

--- a/src/sbt-test/sbteclipse/02-contents/build.sbt
+++ b/src/sbt-test/sbteclipse/02-contents/build.sbt
@@ -225,7 +225,8 @@ TaskKey[Unit]("verify-scala-settings") <<= baseDirectory map { dir =>
     p.asScala.toMap
   }
   val expected = Map(
-    "scala.compiler.additionalParams" -> """-Xprompt""",
+    "scala.compiler.additionalParams" -> """-Xprompt -Xsource:2.10 -Ymacro-expand:none""",
+    "scala.compiler.installation" -> "2.10",
     "verbose" -> "true",
     "deprecation" -> "true",
     "Xelide-below" -> "1000",

--- a/src/sbt-test/sbteclipse/06-multi-scala-version-support/build.sbt
+++ b/src/sbt-test/sbteclipse/06-multi-scala-version-support/build.sbt
@@ -1,0 +1,40 @@
+import java.io.FileInputStream
+import java.io.FileNotFoundException
+import java.util.Properties
+import scala.collection.JavaConverters._
+
+EclipseKeys.skipParents in ThisBuild := false
+
+organization := "com.typesafe.sbteclipse"
+
+name := "sbteclipse-test"
+
+version := "1.2.3"
+
+TaskKey[Unit]("verify-scala-settings-suba") <<= baseDirectory map { dir =>
+  val settings = {
+    val p = new Properties 
+    p.load(new FileInputStream(dir / "suba/.settings/org.scala-ide.sdt.core.prefs"))
+    p.asScala.toMap
+  }
+  val expected = Map(
+    "scala.compiler.additionalParams" -> """-Xsource:2.10 -Ymacro-expand:none""",
+    "scala.compiler.installation" -> "2.10",
+    "scala.compiler.useProjectSettings" -> "true"
+  )
+  if (settings != expected) error("Expected settings to be '%s', but was '%s'!".format(expected, settings))
+}
+
+TaskKey[Unit]("verify-scala-settings-subb") <<= baseDirectory map { dir =>
+  try {
+    val settings = {
+      val p = new Properties
+      p.load(new FileInputStream(dir / "subb/.settings/org.scala-ide.sdt.core.prefs"))
+      p.asScala.toMap
+    }
+    if (settings.nonEmpty) error("Expected settings to be empty, but was '%s'!".format(settings))
+  } catch {
+    // this is OK, for a Scala 2.11 project we don't need to set any special setting
+    case e: FileNotFoundException => ()
+  }
+}

--- a/src/sbt-test/sbteclipse/06-multi-scala-version-support/project/Build.scala
+++ b/src/sbt-test/sbteclipse/06-multi-scala-version-support/project/Build.scala
@@ -1,0 +1,28 @@
+import sbt._
+import sbt.Keys._
+import com.typesafe.sbteclipse.plugin.EclipsePlugin._
+
+object Build extends Build {
+  
+  lazy val dependencies = Seq(
+    "biz.aQute" % "bndlib" % "1.50.0",
+    "org.specs2" %% "specs2" % "2.1.1" % "test"
+  )
+
+  lazy val suba = Project(
+    "suba",
+    new File("suba"),
+    settings = Project.defaultSettings ++ Seq(
+      scalaVersion := "2.10.3"
+    )
+  )
+  
+  lazy val subb = Project(
+    "subb",
+    new File("subb"),
+    settings = Project.defaultSettings ++ Seq(
+      scalaVersion := "2.11.3"
+    )
+  )
+  
+}

--- a/src/sbt-test/sbteclipse/06-multi-scala-version-support/project/plugins.sbt
+++ b/src/sbt-test/sbteclipse/06-multi-scala-version-support/project/plugins.sbt
@@ -1,0 +1,7 @@
+{
+  val pluginVersion = System.getProperty("plugin.version")
+  if(pluginVersion == null)
+    throw new RuntimeException("""|The system property 'plugin.version' is not defined.
+                                  |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % pluginVersion)
+}

--- a/src/sbt-test/sbteclipse/06-multi-scala-version-support/suba/src/main/scala/SubA.scala
+++ b/src/sbt-test/sbteclipse/06-multi-scala-version-support/suba/src/main/scala/SubA.scala
@@ -1,0 +1,1 @@
+object SubA

--- a/src/sbt-test/sbteclipse/06-multi-scala-version-support/subb/src/main/scala/SubB.scala
+++ b/src/sbt-test/sbteclipse/06-multi-scala-version-support/subb/src/main/scala/SubB.scala
@@ -1,0 +1,1 @@
+object SubB

--- a/src/sbt-test/sbteclipse/06-multi-scala-version-support/test
+++ b/src/sbt-test/sbteclipse/06-multi-scala-version-support/test
@@ -1,0 +1,5 @@
+> clean
+> compile
+> eclipse skip-parents=false
+> verify-scala-settings-suba
+> verify-scala-settings-subb

--- a/src/test/scala/com/typesafe/sbteclipse/core/util/ScalaVersionSpec.scala
+++ b/src/test/scala/com/typesafe/sbteclipse/core/util/ScalaVersionSpec.scala
@@ -1,0 +1,33 @@
+package com.typesafe.sbteclipse.core.util
+
+import org.scalatest.WordSpec
+import org.scalatest.Matchers
+import ScalaVersion.FullScalaVersion
+
+class ScalaVersionSpec extends WordSpec with Matchers {
+  "ScalaVersion" should {
+    """parse Scala version "2.10.0"""" in {
+      ScalaVersion.parse("2.10.0") shouldEqual FullScalaVersion(2, 10, 0, None)
+    }
+
+    """parse Scala version "2.10.0-SNAPSHOT"""" in {
+      ScalaVersion.parse("2.10.0-SNAPSHOT") shouldEqual FullScalaVersion(2, 10, 0, Some("SNAPSHOT"))
+    }
+
+    """parse Scala version "2.10.0-RC10"""" in {
+      ScalaVersion.parse("2.10.0-RC10") shouldEqual FullScalaVersion(2, 10, 0, Some("RC10"))
+    }
+
+    """parse Scala version "2.10.0-M1"""" in {
+      ScalaVersion.parse("2.10.0-M1") shouldEqual FullScalaVersion(2, 10, 0, Some("M1"))
+    }
+
+    """parse Scala version "2.10.0-51e77037f2adc4ffa7421aa36803a5874292b70d"""" in {
+      ScalaVersion.parse("2.10.0-51e77037f2adc4ffa7421aa36803a5874292b70d") shouldEqual FullScalaVersion(2, 10, 0, Some("51e77037f2adc4ffa7421aa36803a5874292b70d"))
+    }
+
+    """fail to parse "2.10"""" in {
+      ScalaVersion.parse("2.10") shouldEqual NoScalaVersion
+    }
+  }
+}


### PR DESCRIPTION
The latest Scala IDE 4.0 supports both Scala 2.10 and 2.11 projects. To
correctly export a Scala 2.10 project, a few properties need to be properly set.