### PR TITLE
Removed custom jvmopts for travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ cache:
   directories:
   - $HOME/.ivy2
 script:
-  - sbt ++$TRAVIS_SCALA_VERSION -jvm-opts .travis/jvmopts scripted
+  - sbt scripted

--- a/.travis/jvmopts
+++ b/.travis/jvmopts
@@ -1,5 +1,0 @@
--Dfile.encoding=UTF8
--Xms3072M
--Xmx3072M
--XX:MaxPermSize=3072M
--XX:+CMSClassUnloadingEnabled


### PR DESCRIPTION
I think we don't need to use any custom jvmopts, so let's see.