### PR TITLE
Automatic detection of the project's flavor. Fix #277

### DIFF
--- a/src/main/scala/com/typesafe/sbteclipse/core/EclipseOpts.scala
+++ b/src/main/scala/com/typesafe/sbteclipse/core/EclipseOpts.scala
@@ -29,6 +29,4 @@ private object EclipseOpts {
   val WithJavadoc = "with-javadoc"
 
   val UseProjectId = "use-project-id"
-
-  val WithBundledScalaContainers = "with-bundled-scala-containers"
 }

--- a/src/main/scala/com/typesafe/sbteclipse/core/package.scala
+++ b/src/main/scala/com/typesafe/sbteclipse/core/package.scala
@@ -27,4 +27,6 @@ package object core {
   val FileSep = System.getProperty("file.separator")
 
   type Validation[A] = scalaz.Validation[NonEmptyList[String], A]
+
+  val IssueTracker = "https://github.com/typesafehub/sbteclipse/issues"
 }

--- a/src/sbt-test/sbteclipse/07-pure-java-project/build.sbt
+++ b/src/sbt-test/sbteclipse/07-pure-java-project/build.sbt
@@ -1,0 +1,28 @@
+import scala.xml.XML
+
+organization := "com.typesafe.sbteclipse"
+
+name := "sbteclipse-test"
+
+version := "1.2.3"
+
+autoScalaLibrary := false
+
+TaskKey[Unit]("verify-project-xml") <<= baseDirectory map { dir =>
+  val projectDescription = XML.loadFile(dir / ".project")
+  // verifier method
+  def verify[A](name: String, expected: A, actual: A) =
+    if (actual != expected) error("Expected .project to contain %s '%s', but was '%s'!".format(name, expected, actual))
+  def verifyNot[A](name: String, expected: A, actual: => A) = {
+    try if (actual != expected) error("Expected .project to contain %s '%s', but was '%s'!".format(name, expected, actual))
+    catch {
+      case _: RuntimeException => () // this is expected and means the test was OK
+    }
+  }
+  // java project nature
+  verify("buildCommand", "org.eclipse.jdt.core.javabuilder", (projectDescription \ "buildSpec" \ "buildCommand" \ "name").text)
+  verify("natures", "org.eclipse.jdt.core.javanature", (projectDescription \ "natures" \ "nature").text)
+  // no scala nature for pure java project
+  verifyNot("buildCommand", "org.scala-ide.sdt.core.scalabuilder", (projectDescription \ "buildSpec" \ "buildCommand" \ "name").text)
+  verifyNot("natures", "org.scala-ide.sdt.core.scalanature", (projectDescription \ "natures" \ "nature").text)
+}

--- a/src/sbt-test/sbteclipse/07-pure-java-project/project/plugins.sbt
+++ b/src/sbt-test/sbteclipse/07-pure-java-project/project/plugins.sbt
@@ -1,0 +1,7 @@
+{
+  val pluginVersion = System.getProperty("plugin.version")
+  if(pluginVersion == null)
+    throw new RuntimeException("""|The system property 'plugin.version' is not defined.
+                                  |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % pluginVersion)
+}

--- a/src/sbt-test/sbteclipse/07-pure-java-project/src/main/java/play/api/UsefulException.java
+++ b/src/sbt-test/sbteclipse/07-pure-java-project/src/main/java/play/api/UsefulException.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.api;
+
+/**
+* A UsefulException is something useful to display in the User browser.
+*/
+public abstract class UsefulException extends RuntimeException {
+
+    /**
+     * Exception title.
+     */
+    public String title;
+  
+    /**
+     * Exception description.
+     */
+    public String description; 
+  
+    /**
+     * Exception cause if defined.
+     */
+    public Throwable cause;
+  
+    /**
+     * Unique id for this exception.
+     */
+    public String id;
+  
+    public UsefulException(String message, Throwable cause) {
+      super(message, cause);
+    }
+    
+    public UsefulException(String message) {
+      super(message);
+    }
+
+    public String toString() {
+        return "@" + id + ": " + title;
+    }
+
+} 

--- a/src/sbt-test/sbteclipse/07-pure-java-project/test
+++ b/src/sbt-test/sbteclipse/07-pure-java-project/test
@@ -1,0 +1,2 @@
+> eclipse
+> verify-project-xml


### PR DESCRIPTION
When importing a stock Java project, with no dependency on Scala (usually,
because sbt setting `autoScalaLibrary` is set to `false`), it doesn't make sense
to add the Scala builder and nature to the Eclipse .classpath file.  In fact,
doing so it's actually going to cause issues as soon as the project is imported,
because the Scala nature is active but no scala-library.jar was found, and hence
the sbteclipse xml transformation for swapping the scala-library.jar with the
Scala bundle was not executed.

The proposed solution to fix the above problem is to have a new default flavour:
Autodetect. Autodetect will detect the right project's flavour based on the fact
that the scala-library.jar is, or isn't, in the classpath.

This commit, together with the fix for #239, makes the
`WithBundledScalaContainers` obsolete. First, the Scala bundle should always be
used when importing a Scala project, and it should never be used when it's a
Java project. The new Autodetect flavour takes care of this. Second, the actual
reason why `WithBundledScalaContainers` was introduced was to properly import
Scala 2.10 projects in the Scala IDE 4.0. #239 fixes exactly this problem (i.e.,
Scala 2.10 projects are now imported with the right scalac options), making
`WithBundledScalaContainers` indeed obsolete.