### PR TITLE
Move defaults to globalSettings (fix #296), try #2

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -9,7 +9,7 @@ import com.typesafe.sbt.SbtGit._
 
 object Build extends Build {
 
-  val baseVersion = "4.0.0"
+  val baseVersion = "5.0.0"
   val maxMetaspaceSize = if (util.Properties.isJavaAtLeast("1.8")) {
     "-XX:MaxMetaspaceSize=384m"
   } else {

--- a/src/main/scala/com/typesafe/sbteclipse/core/EclipsePlugin.scala
+++ b/src/main/scala/com/typesafe/sbteclipse/core/EclipsePlugin.scala
@@ -46,21 +46,11 @@ object EclipsePlugin {
       commandName := "eclipse",
       commands <+= (commandName)(Eclipse.eclipseCommand),
       managedClassDirectories := Seq((classesManaged in sbt.Compile).value, (classesManaged in sbt.Test).value),
-      executionEnvironment := None,
-      useProjectId := false,
-      skipParents := true,
-      withSource := false,
-      withJavadoc := false,
-      projectFlavor := EclipseProjectFlavor.ScalaIDE,
-      withBundledScalaContainers := projectFlavor.value.id == EclipseProjectFlavor.ScalaIDE.id,
+      preTasks := Seq(),
+      skipProject := false,
       classpathTransformerFactories := defaultClasspathTransformerFactories(withBundledScalaContainers.value),
       projectTransformerFactories := Seq(EclipseRewriteRuleTransformerFactory.Identity),
-      configurations := Set(Configurations.Compile, Configurations.Test),
-      createSrc := EclipseCreateSrc.Default,
-      eclipseOutput := None,
-      preTasks := Seq(),
-      relativizeLibs := true,
-      skipProject := false
+      configurations := Set(Configurations.Compile, Configurations.Test)
     ) ++ copyManagedSettings(sbt.Compile) ++ copyManagedSettings(sbt.Test)
   }
 
@@ -80,6 +70,21 @@ object EclipsePlugin {
       // project disables the EclipsePlugin, the project level default won't be set, and so it will fall back to this
       // build level setting, which means the project will be skipped.
       skipProject := true
+    )
+  }
+
+  def globalEclipseSettings: Seq[Setting[_]] = {
+    import EclipseKeys._
+    Seq(
+      executionEnvironment := None,
+      useProjectId := false,
+      withSource := false,
+      withJavadoc := false,
+      withBundledScalaContainers := projectFlavor.value.id == EclipseProjectFlavor.ScalaIDE.id,
+      projectFlavor := EclipseProjectFlavor.ScalaIDE,
+      createSrc := EclipseCreateSrc.Default,
+      eclipseOutput := None,
+      relativizeLibs := true
     )
   }
 

--- a/src/main/scala/com/typesafe/sbteclipse/plugin/EclipsePlugin.scala
+++ b/src/main/scala/com/typesafe/sbteclipse/plugin/EclipsePlugin.scala
@@ -32,6 +32,7 @@ object EclipsePlugin extends AutoPlugin {
   val autoImport: EclipseCorePlugin.type = EclipseCorePlugin
   override def projectSettings: Seq[Setting[_]] = EclipseCorePlugin.eclipseSettings
   override def buildSettings: Seq[Setting[_]] = EclipseCorePlugin.buildEclipseSettings
+  override def globalSettings: Seq[Setting[_]] = EclipseCorePlugin.globalEclipseSettings
   // Alias for existing things.
   val EclipseKeys = EclipseCorePlugin.EclipseKeys
   val EclipseProjectFlavor = EclipseCorePlugin.EclipseProjectFlavor


### PR DESCRIPTION
New edition of #299, bumping major version as requested by @jsuereth.

## Original description
[SBT docs](http://www.scala-sbt.org/0.13/docs/Plugins.html#projectSettings+and+buildSettings) recommend:
“Use globalSettings to define the default value of a setting.”

`sbteclipse` doesn't do that, causing #296 and other variants. This PR fixes that bug. However, I'm not 100% sure that I'm moving all settings that should be moved.