### PR TITLE
Ensure Eclipse plugin works when disabled

### DIFF
--- a/src/main/scala/com/typesafe/sbteclipse/core/EclipsePlugin.scala
+++ b/src/main/scala/com/typesafe/sbteclipse/core/EclipsePlugin.scala
@@ -75,7 +75,11 @@ object EclipsePlugin {
   def buildEclipseSettings: Seq[Setting[_]] = {
     import EclipseKeys._
     Seq(
-      skipParents := true
+      skipParents := true,
+      // Typically, this will be overridden for each project by the project level default of false. However, if a
+      // project disables the EclipsePlugin, the project level default won't be set, and so it will fall back to this
+      // build level setting, which means the project will be skipped.
+      skipProject := true
     )
   }
 

--- a/src/sbt-test/sbteclipse/07-disabled-plugin/build.sbt
+++ b/src/sbt-test/sbteclipse/07-disabled-plugin/build.sbt
@@ -1,0 +1,3 @@
+lazy val projectA = project in file("a")
+lazy val projectB = (project in file("b"))
+  .disablePlugins(EclipsePlugin)

--- a/src/sbt-test/sbteclipse/07-disabled-plugin/project/plugins.sbt
+++ b/src/sbt-test/sbteclipse/07-disabled-plugin/project/plugins.sbt
@@ -1,0 +1,7 @@
+{
+  val pluginVersion = System.getProperty("plugin.version")
+  if(pluginVersion == null)
+    throw new RuntimeException("""|The system property 'plugin.version' is not defined.
+                                  |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % pluginVersion)
+}

--- a/src/sbt-test/sbteclipse/07-disabled-plugin/test
+++ b/src/sbt-test/sbteclipse/07-disabled-plugin/test
@@ -1,0 +1,3 @@
+> eclipse
+$ exists a/.classpath
+-$ exists b/.classpath


### PR DESCRIPTION
In some situations, the eclipse plugin may be disabled on a particular project.  If this happens, the eclipse command fails, saying the skipProject setting can't be found for that project.  This ensures that in that situation, skipProject defaults to true, so that it doesn't fail, and the project is instead skipped.

My particular use case is that we're writing a plugin that dynamically adds new projects to an sbt build - these projects are meta projects that resolve dependencies for services that need to be run, but not on the classpath of the users project.  This dynamic project addition does not apply auto plugins, it's very specific about which settings get enabled on the dynamically added projects, so the eclipse plugin for example is not enabled on it, and we don't want it to be enabled, this is a meta project, not something that should appear in a users eclipse project.  And we shouldn't have to make this project depend on the eclipse plugin just to disable the eclipse plugin.