### PR TITLE
Switch to scalaz 7.2

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -21,8 +21,8 @@ object Build extends Build {
     file("."),
     settings = commonSettings ++ Seq(
       libraryDependencies ++= Seq(
-        "org.scalaz"    %% "scalaz-core"   % "7.1.0",
-        "org.scalaz"    %% "scalaz-effect" % "7.1.0",
+        "org.scalaz"    %% "scalaz-core"   % "7.2.5",
+        "org.scalaz"    %% "scalaz-effect" % "7.2.5",
         "org.scalatest" %% "scalatest"     % "2.2.1" % "test")
     )
   )


### PR DESCRIPTION
This seems to be fine without needing any code change. (At least, the switch doesn't make more tests fail on my machine :-)

scalaz 7.2 has been out for some time now, and sticking to scalaz 7.1 makes sbteclipse run into binary incompatibility issues when used along plugins using scalaz 7.2. See the recent comments in https://github.com/typesafehub/sbteclipse/issues/221.