### PR TITLE
Bugfix: Make sure managedClassDirectories always gets added to .classpath and filesystem

### DIFF
--- a/src/main/scala/com/typesafe/sbteclipse/core/Eclipse.scala
+++ b/src/main/scala/com/typesafe/sbteclipse/core/Eclipse.scala
@@ -497,7 +497,7 @@ private object Eclipse extends EclipseSDTConfig {
     def libs(files: Seq[Attributed[File]], moduleFiles: Map[File, Lib]): Seq[Lib] = {
       var result: Seq[Lib] = files.files map { file => moduleFiles.get(file).getOrElse(Lib(file)(None)(None)) }
       if (createSrc(ref, state)(configuration).contains(EclipseCreateSrc.ManagedClasses)) {
-        result = result ++ managedClassDirectories(ref, state)(configuration).filter(_.exists).map(Lib(_)(None)(None))
+        result = result ++ managedClassDirectories(ref, state)(configuration).map(Lib(_)(None)(None))
       }
       result
     }

--- a/src/main/scala/com/typesafe/sbteclipse/core/EclipsePlugin.scala
+++ b/src/main/scala/com/typesafe/sbteclipse/core/EclipsePlugin.scala
@@ -119,6 +119,9 @@ object EclipsePlugin {
         val managedClasses = ((srcManaged ** "*.scala").get ++ (srcManaged ** "*.java").get).map { managedSourceFile =>
           analysis.relations.products(managedSourceFile)
         }.flatten pair rebase(classes, managedClassesDirectory)
+        // Always create folder to make sure it exists - even if (or better: in case that) there are no class files to copy
+        // Otherwise Eclipse will complain it's missing the folder (because it gets added in .classpath).
+        IO.createDirectory(managedClassesDirectory)
         // Copy modified class files
         val managedSet = IO.copy(managedClasses)
         // Remove deleted class files


### PR DESCRIPTION
# What's the problem?
When creating a new Play Framework project (or checking out an existing one) that has **no** `target` folder yet (because the project wasn't compiled yet) and run `sbt eclipse` on such a not-yet-compiled and not-yet-eclipsified Play project the `target/scala-2.11/classes_managed` folder won't get added to the `.classpath` file (despite it gets created on the filesystem eventually) - which results in a lot of errors when importing the project in eclipse.

**Most users won't recognize this bug because they probably run `sbt eclipse` _after_ they already compiled their project at least once - having therefore created the `target/scala-2.11/classes_managed` folder already.**

# How does this happen?
That's because right now we add managedClassDirectory folders to the `.classpath` file **only if the folder does exists on the filesystem** - but because the compilation from `preTasks` hasn't been done yet the folder isn't there yet. 

# How to fix?
The fix is to remove `filter(_.exists)` you see in this change. (I don't understand why this was filtered at all because we expliticly say we want to use this directory on the classpath).
After this change (removal of the filter) we now get `target/scala-2.11/classes_managed` added to the .classpath file (perfect!) - but not only this: Because by default the managed class directories for both the `compile` and `test` scope are set (see [here](https://github.com/typesafehub/sbteclipse/blob/v5.0.1/src/main/scala/com/typesafe/sbteclipse/core/EclipsePlugin.scala#L48)) also the lib entry `target/scala-2.11/`**`test-`**`classes_managed` gets added to `.classpath` (which is correct and should have been always like this).
But in a fresh new Play application there are no managed test classes yet, therefore this `test-classes_managed` folder won't get created on the filesystem by default (no files to compile and to copy) - making Eclipse complain it's missing the folder. Hence with my second change I make sure at last the folder itself gets created even when it's empty because nothing got compiled/copied.

# One more thing
When you follow the [Play docs](https://www.playframework.com/documentation/2.5.x/IDE) to setup Eclipse you end up having following settings in your `build.sbt`:
```
EclipseKeys.preTasks := Seq(compile in Compile)
EclipseKeys.projectFlavor := EclipseProjectFlavor.Java
EclipseKeys.createSrc := EclipseCreateSrc.ValueSet(EclipseCreateSrc.ManagedClasses, EclipseCreateSrc.ManagedResources)
```

This has to be changed to also compile in Test scope because (as mentioned above) [by default the managed class directories for both the `compile` and `test` scope are set](https://github.com/typesafehub/sbteclipse/blob/v5.0.1/src/main/scala/com/typesafe/sbteclipse/core/EclipsePlugin.scala#L48):
```
EclipseKeys.preTasks := Seq(compile in Compile, compile in Test)
```
Actually it should have been like this before my PR already. I will provide another PR for the Play docs with this change.