### PR TITLE
Plugin broken for pure Java-Eclipse users when using sbt 1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ matrix:
     scala: 2.10.6
   - env: SBT_VERSION="1.0.0"
     jdk: oraclejdk8
-    scala: 2.12.3
+    scala: 2.12.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,6 @@ matrix:
   - env: SBT_VERSION="0.13.16"
     jdk: oraclejdk7
     scala: 2.10.6
-  - env: SBT_VERSION="1.0.0"
+  - env: SBT_VERSION="1.0.2"
     jdk: oraclejdk8
     scala: 2.12.4

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import sbt.ScriptedPlugin._
 import _root_.bintray.BintrayPlugin.bintrayPublishSettings
 
-crossSbtVersions := Seq("1.0.0", "0.13.16")
+crossSbtVersions := Seq("1.0.2", "0.13.16")
 
 val baseVersion = "5.2.3-SNAPSHOT"
 

--- a/build.sbt
+++ b/build.sbt
@@ -42,9 +42,9 @@ def commonSettings = {
     ),
     scalaVersion := {
       (sbtVersion in GlobalScope).value match {
-        case sbt10  if sbt10.startsWith("1.0") => "2.12.3"
+        case sbt10  if sbt10.startsWith("1.0") => "2.12.4"
         case sbt013 if sbt013.startsWith("0.13.") => "2.10.6"
-        case _ => "2.12.3"
+        case _ => "2.12.4"
       }
     },
     sbtDependency in GlobalScope := {

--- a/src/main/scala-sbt-0.13/com/typesafe/sbteclipse/core/EclipsePlugin.scala
+++ b/src/main/scala-sbt-0.13/com/typesafe/sbteclipse/core/EclipsePlugin.scala
@@ -23,7 +23,6 @@ import sbt.{
   Configurations,
   File,
   Keys,
-  Plugin,
   ProjectRef,
   ResolvedProject,
   Setting,

--- a/src/main/scala-sbt-1.0/com/typesafe/sbteclipse/core/EclipsePlugin.scala
+++ b/src/main/scala-sbt-1.0/com/typesafe/sbteclipse/core/EclipsePlugin.scala
@@ -103,7 +103,7 @@ object EclipsePlugin {
   // to handle these if you put them in a source folder without Scala IDE installed. The workaround added here is to not
   // add the scala managed sources to the classpath, but rather to add the compiled classes to the classpath instead.
   def copyManagedClasses(scope: Configuration) =
-    Def.taskDyn {
+    Def.task {
       import sbt._
       val analysis = (Keys.compile in scope).value
       if ((EclipseKeys.generateClassesManaged in scope).value) {
@@ -121,7 +121,7 @@ object EclipsePlugin {
         // Remove deleted class files
         (managedClassesDirectory ** "*.class").get.filterNot(managedSet.contains(_)).foreach(_.delete())
       }
-      Def.task(analysis)
+      analysis
     }
 
   object EclipseKeys {

--- a/src/sbt-test/sbteclipse/02-contents/build.sbt
+++ b/src/sbt-test/sbteclipse/02-contents/build.sbt
@@ -15,7 +15,7 @@ lazy val root =
       unmanagedSourceDirectories in Compile += { baseDirectory(new File(_, "src/main/scala")).value },
       unmanagedSourceDirectories in Test += { baseDirectory(new File(_, "src/test/scala")).value },
       libraryDependencies ++= Seq(
-        "org.scala-lang" % "scala-compiler" % "2.12.3",
+        "org.scala-lang" % "scala-compiler" % "2.12.4",
         "biz.aQute.bnd" % "biz.aQute.bndlib" % "3.4.0"
       ),
       retrieveManaged := true

--- a/src/sbt-test/sbteclipse/02-contents/test
+++ b/src/sbt-test/sbteclipse/02-contents/test
@@ -1,4 +1,4 @@
-$ mkdir target/scala-2.12.3/src_managed/main
+$ mkdir target/scala-2.12.4/src_managed/main
 > eclipse skip-parents=false
 > verifyProjectXml
 > verifyProjectXmlJava

--- a/src/sbt-test/sbteclipse/06-multi-scala-version-support/build.sbt
+++ b/src/sbt-test/sbteclipse/06-multi-scala-version-support/build.sbt
@@ -15,6 +15,6 @@ lazy val subb =
   Project("subb", new File("subb")).
   settings(
     Defaults.coreDefaultSettings ++ Seq(
-      scalaVersion := "2.12.3"
+      scalaVersion := "2.12.4"
     )
   )


### PR DESCRIPTION
First of all I am not really a sbt expert. However I am in the process of upgrading our (pure play-java) projects to sbt 1.0 and for us the sbt-eclipse plugin is broken - neither reverse routes nor view classes can be found by Eclipse (we are **not** using Scala IDE).
Turned out the `classes_managed` folder that should contain these classes wasn't even created... (but that is working when using sbt 0.13.16)

@godenji introduced a workaround in #345 to replace the line `analysis.relations.products(managedSourceFile)` necessary for sbt 1.0 support (because `.relations...` doesn't exist anymore).
However this `compileTargets.filter(...)` workaround doesn't work at all. For us this filtering makes `val managedClasses` an empty list all the time and as a consequence no class files get copied into a `classes_managed` folder (that folder therefore will not even be created). I tried to track down what this filtering is doing and I just cant make any sense of it, for me that filter logic is just plain wrong and will always return `false` resulting in an empty list every time.

However it turns out there is a much simpler approch: It's possible to cast `analysis` to `sbt.internal.inc.Analysis` so we still have the necessary methods/fields available. This is how it is done in the `play-enhancer` project for example: https://github.com/playframework/play-enhancer/pull/16/files#diff-9a4e781654b04d2870298edcc1d23e82R73
We can now also remove the `taskDyn` and keep the code almost the same like for sbt 0.13.x.
E.g. if you diff `src/main/scala-sbt-0.13/com/typesafe/sbteclipse/core/EclipsePlugin.scala` with `src/main/scala-sbt-1.0/com/typesafe/sbteclipse/core/EclipsePlugin.scala` after applying this pull request there is just this cast now but not much more that differs. Plus the plugin is working again now even when using sbt 1.0; eclipse projects will be generated correctly.

I also updated to latest Scala and sbt version.