### PR TITLE
extended scope of eclipseOutput setting to override eclipse bin default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ out/
 
 # Mac
 .DS_Store
+
+# Vim
+*.swp

--- a/src/main/scala-sbt-0.13/com/typesafe/sbteclipse/core/Eclipse.scala
+++ b/src/main/scala-sbt-0.13/com/typesafe/sbteclipse/core/Eclipse.scala
@@ -305,14 +305,14 @@ private object Eclipse extends EclipseSDTConfig {
       srcEntries <- srcEntriesIoSeq.toList.sequence;
       linkEntries <- srcLinkEntriesIoSeq.toList.sequence
     ) yield {
-      val eodirs: Seq[String] = for {
+      val eclipseOutputDirs: Seq[String] = for {
         (fa: File, ta: Option[File]) <- srcDirectories
-        eopath = ta match {
+        eclipseOutputPath = ta match {
           case Some(dd) => relativize(baseDirectory, dd).toString
           case None => ""
         }
-      } yield eopath
-      val classDirectory = eodirs.filter { _.nonEmpty }.distinct match {
+      } yield eclipseOutputPath
+      val classDirectory = eclipseOutputDirs.filter { _.nonEmpty }.distinct match {
         case dir :: _ => dir
         case _ => "bin" // this is the eclipse default
       }

--- a/src/main/scala-sbt-0.13/com/typesafe/sbteclipse/core/Eclipse.scala
+++ b/src/main/scala-sbt-0.13/com/typesafe/sbteclipse/core/Eclipse.scala
@@ -305,16 +305,11 @@ private object Eclipse extends EclipseSDTConfig {
       srcEntries <- srcEntriesIoSeq.toList.sequence;
       linkEntries <- srcLinkEntriesIoSeq.toList.sequence
     ) yield {
-      val eclipseOutputDirs: Seq[String] = for {
-        (fa: File, ta: Option[File]) <- srcDirectories
-        eclipseOutputPath = ta match {
-          case Some(dd) => relativize(baseDirectory, dd).toString
-          case None => ""
-        }
-      } yield eclipseOutputPath
-      val classDirectory = eclipseOutputDirs.filter { _.nonEmpty }.distinct match {
-        case dir :: _ => dir
-        case _ => "bin" // this is the eclipse default
+      def classDirectory = srcEntries.flatMap { _.output }.distinct match {
+        case Nil =>
+          "bin"
+        case dir :: _ =>
+          dir
       }
       val entries = srcEntries ++ linkEntries ++
         (projectDependencies map EclipseClasspathEntry.Project) ++

--- a/src/main/scala-sbt-1.0/com/typesafe/sbteclipse/core/Eclipse.scala
+++ b/src/main/scala-sbt-1.0/com/typesafe/sbteclipse/core/Eclipse.scala
@@ -305,14 +305,14 @@ private object Eclipse extends EclipseSDTConfig {
       srcEntries <- srcEntriesIoSeq.toList.sequence;
       linkEntries <- srcLinkEntriesIoSeq.toList.sequence
     ) yield {
-      val eodirs: Seq[String] = for {
+      val eclipseOutputDirs: Seq[String] = for {
         (fa: File, ta: Option[File]) <- srcDirectories
-        eopath = ta match {
+        eclipseOutputPath = ta match {
           case Some(dd) => relativize(baseDirectory, dd).toString
           case None => ""
         }
-      } yield eopath
-      val classDirectory = eodirs.filter { _.nonEmpty }.distinct match {
+      } yield eclipseOutputPath
+      val classDirectory = eclipseOutputDirs.filter { _.nonEmpty }.distinct match {
         case dir :: _ => dir
         case _ => "bin" // this is the eclipse default
       }

--- a/src/main/scala-sbt-1.0/com/typesafe/sbteclipse/core/Eclipse.scala
+++ b/src/main/scala-sbt-1.0/com/typesafe/sbteclipse/core/Eclipse.scala
@@ -305,16 +305,11 @@ private object Eclipse extends EclipseSDTConfig {
       srcEntries <- srcEntriesIoSeq.toList.sequence;
       linkEntries <- srcLinkEntriesIoSeq.toList.sequence
     ) yield {
-      val eclipseOutputDirs: Seq[String] = for {
-        (fa: File, ta: Option[File]) <- srcDirectories
-        eclipseOutputPath = ta match {
-          case Some(dd) => relativize(baseDirectory, dd).toString
-          case None => ""
-        }
-      } yield eclipseOutputPath
-      val classDirectory = eclipseOutputDirs.filter { _.nonEmpty }.distinct match {
-        case dir :: _ => dir
-        case _ => "bin" // this is the eclipse default
+      def classDirectory = srcEntries.flatMap { _.output }.distinct match {
+        case Nil =>
+          "bin"
+        case dir :: _ =>
+          dir
       }
       val entries = srcEntries ++ linkEntries ++
         (projectDependencies map EclipseClasspathEntry.Project) ++

--- a/src/sbt-test/sbteclipse/02-contents/tasks.sbt
+++ b/src/sbt-test/sbteclipse/02-contents/tasks.sbt
@@ -208,6 +208,8 @@ TaskKey[Unit]("verify-classpath-xml-subc") := {
     error("""Expected .classpath of subc project to contain <classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/> """)
   if (!(classpath.child contains <classpathentry kind="lib" path="libs/my.jar"/>))
     error("""Expected .classpath of subc project to contain <classpathentry kind="lib" path="libs/my.jar"/>!""")
+  if (!(classpath.child contains <classpathentry kind="output" path=".target" />))
+    error("""Expected .classpath of subc project to contain <classpathentry kind="output" path=".target" /> """)
   if (!(project.child contains <foo bar="baz"/>))
     error("""Expected .project of subc project to contain <foo bar="baz"/>!""")
 }


### PR DESCRIPTION
This addresses issues raised in the discussion for #352, specifically:

eclipseOutput setting correctly affects the path values of the following entries:

```
  <classpathentry output=".target" kind="src" path="src\main\scala"/>
  <classpathentry output=".target" kind="src" path="target\scala-2.12\src_managed\main"/>
  <classpathentry output=".target" kind="src" path="src\test\scala"/>
```
However, it should also determine the value generated for this entry as well:
```
<classpathentry kind="output" path=".target"/>
```
This latter entry has been hard-wired to the value of "bin" prior to these changes.

A test case was added to `src/sbt-test/sbteclipse/02-contents/tasks.sbt` to verify the expected changed path value.   All scripted tests pass in two test environments:

- Windows 10 / WSL ubuntu x86_64
- Linux Mint 18.2 Sonya x86_64

A possible remaining issue not addressed by this change is that there is no coordination or warning when a mismatch exists between the `eclipseOutput` setting and the standard sbt `target` setting, although it would seem that they should be referring to the same directory in most if not all cases.


