### PR TITLE
Improved support for multiple scala versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,30 @@ For the latest version:
 
 - In Eclipse use the *Import Wizard* to import *Existing Projects into Workspace*
 
+
+
+Multi ScalaVersion support
+-------------------
+
+Since Scala IDE 4.0 multiple scala versions are supported in a single eclipse workspace. The Scala IDE uses by default the highest supported scala version, 2.11 since Scala IDE 4.0 and 2.12 since Scala IDE 4.6. The default can be overwritten at workspace level or at project level. The latter is stored in the file `.settings/org.scala-ide.sdt.core.prefs`. This file can be generated with sbteclipse. 
+
+**For sbteclipse 5.2.5 and up**
+
+Given
+  ```
+  EclipseKeys.defaultScalaInstallation := "xD.yD" // "2.12" is the default
+  ScalaVersion := "x.y.z"
+  ```
+In case `x.y` < `xD.yD`, the lower `scala.compiler.installation` is configured at project level.
+
+When you're using ScalaIDE-4.6.0 up to 4.7._ (until a new major scala version is the default), and x.y.z matches with one of the pre-installed scala compilers in the IDE, it should work fine out of the box.  
+
+**For sbteclipse 4.0. up to 5.2.4**
+
+In case `x.y` = `2.10`, the lower `scala.compiler.installation` is configured at project level.
+
+When you're using ScalaIDE-4.0 up to 4.5._, and x.y.z matches with one of the pre-installed scala compilers in the IDE, it should work fine out of the box.  
+
 Contribution policy
 -------------------
 

--- a/README.md
+++ b/README.md
@@ -31,18 +31,18 @@ Since Scala IDE 4.0 multiple scala versions are supported in a single eclipse wo
 
 **For sbteclipse 5.2.5 and up**
 
-Given
+Given `Xi.Yi` is the default Scala installation version of your Scala IDE, and `Xp.Yp.Zp` is the targetted scala version of your project, you add following in your sbt build file:
   ```
-  EclipseKeys.defaultScalaInstallation := "xD.yD" // "2.12" is the default
-  ScalaVersion := "x.y.z"
+  EclipseKeys.defaultScalaInstallation := "Xi.Yi" // "2.12" is the default
+  ScalaVersion := "Xp.Yp.Zp"
   ```
-In case `x.y` < `xD.yD`, the lower `scala.compiler.installation` is configured at project level.
+In case `Xp.Yp` < `Xi.Yi`, the lower `scala.compiler.installation` is configured at project level.
 
 When you're using ScalaIDE-4.6.0 up to 4.7._ (until a new major scala version is the default), and x.y.z matches with one of the pre-installed scala compilers in the IDE, it should work fine out of the box.  
 
 **For sbteclipse 4.0. up to 5.2.4**
 
-In case `x.y` = `2.10`, the lower `scala.compiler.installation` is configured at project level.
+In case `Xp.Yp` = `2.10`, the lower `scala.compiler.installation` is configured at project level.
 
 When you're using ScalaIDE-4.0 up to 4.5._, and x.y.z matches with one of the pre-installed scala compilers in the IDE, it should work fine out of the box.  
 

--- a/src/main/scala-sbt-0.13/com/typesafe/sbteclipse/core/Eclipse.scala
+++ b/src/main/scala-sbt-0.13/com/typesafe/sbteclipse/core/Eclipse.scala
@@ -436,9 +436,9 @@ private object Eclipse extends EclipseSDTConfig {
   def scalacOptions(ref: ProjectRef, state: State): Validation[Seq[(String, String)]] = {
     // Here we have to look at scalacOptions *for compilation*, vs. the ones used for testing.
     // We have to pick one set, and this should be the most complete set.
-    (evaluateTask(Keys.scalacOptions in sbt.Compile, ref, state) |@| settingValidation(Keys.scalaVersion in ref, state)) { (options, version) =>
+    (evaluateTask(Keys.scalacOptions in sbt.Compile, ref, state) |@| settingValidation(EclipseKeys.defaultScalaInstallation in ref, state) |@| settingValidation(Keys.scalaVersion in ref, state)) { (options, installation, version) =>
       val ideSettings = fromScalacToSDT(options)
-      ScalaVersion.parse(version).settingsFrom(ideSettings.toMap).toSeq
+      ScalaVersion.parse(installation, version).settingsFrom(ideSettings.toMap).toSeq
     } map { options => if (options.nonEmpty) ("scala.compiler.useProjectSettings" -> "true") +: options else options }
   }
 

--- a/src/main/scala-sbt-0.13/com/typesafe/sbteclipse/core/Eclipse.scala
+++ b/src/main/scala-sbt-0.13/com/typesafe/sbteclipse/core/Eclipse.scala
@@ -436,9 +436,9 @@ private object Eclipse extends EclipseSDTConfig {
   def scalacOptions(ref: ProjectRef, state: State): Validation[Seq[(String, String)]] = {
     // Here we have to look at scalacOptions *for compilation*, vs. the ones used for testing.
     // We have to pick one set, and this should be the most complete set.
-    (evaluateTask(Keys.scalacOptions in sbt.Compile, ref, state) |@| settingValidation(EclipseKeys.defaultScalaInstallation in ref, state) |@| settingValidation(Keys.scalaVersion in ref, state)) { (options, installation, version) =>
+    (evaluateTask(Keys.scalacOptions in sbt.Compile, ref, state) |@| settingValidation(EclipseKeys.defaultScalaInstallation in ref, state) |@| settingValidation(Keys.scalaVersion in ref, state)) { (options, installationVersion, projectVersion) =>
       val ideSettings = fromScalacToSDT(options)
-      ScalaVersion.parse(installation, version).settingsFrom(ideSettings.toMap).toSeq
+      ScalaVersion.parse(installationVersion, projectVersion).settingsFrom(ideSettings.toMap).toSeq
     } map { options => if (options.nonEmpty) ("scala.compiler.useProjectSettings" -> "true") +: options else options }
   }
 

--- a/src/main/scala-sbt-0.13/com/typesafe/sbteclipse/core/EclipsePlugin.scala
+++ b/src/main/scala-sbt-0.13/com/typesafe/sbteclipse/core/EclipsePlugin.scala
@@ -49,6 +49,7 @@ object EclipsePlugin {
       preTasks := Seq(),
       skipProject := false,
       withBundledScalaContainers := projectFlavor.value.id == EclipseProjectFlavor.ScalaIDE.id,
+      defaultScalaInstallation := "2.12",
       classpathTransformerFactories := defaultClasspathTransformerFactories(withBundledScalaContainers.value),
       projectTransformerFactories := Seq(EclipseRewriteRuleTransformerFactory.Identity),
       configurations := Set(Configurations.Compile, Configurations.Test)) ++ copyManagedSettings(sbt.Compile) ++ copyManagedSettings(sbt.Test)
@@ -145,6 +146,10 @@ object EclipsePlugin {
     val withBundledScalaContainers: SettingKey[Boolean] = SettingKey(
       prefix(WithBundledScalaContainers),
       "Let the generated project use the bundled Scala library of the ScalaIDE plugin")
+
+    val defaultScalaInstallation: SettingKey[String] = SettingKey(
+      prefix(DefaultScalaInstallation),
+      """The default Scala installation configured in the ScalaIDE workspace, e.g. "2.12" for ScalaIDE 4.7.0, "2.11" for ScalaIDE 4.5.0 """)
 
     val useProjectId: SettingKey[Boolean] = SettingKey(
       prefix(UseProjectId),

--- a/src/main/scala-sbt-1.0/com/typesafe/sbteclipse/core/Eclipse.scala
+++ b/src/main/scala-sbt-1.0/com/typesafe/sbteclipse/core/Eclipse.scala
@@ -436,9 +436,9 @@ private object Eclipse extends EclipseSDTConfig {
   def scalacOptions(ref: ProjectRef, state: State): Validation[Seq[(String, String)]] = {
     // Here we have to look at scalacOptions *for compilation*, vs. the ones used for testing.
     // We have to pick one set, and this should be the most complete set.
-    (evaluateTask(Keys.scalacOptions in sbt.Compile, ref, state) |@| settingValidation(Keys.scalaVersion in ref, state)) { (options, version) =>
+    (evaluateTask(Keys.scalacOptions in sbt.Compile, ref, state) |@| settingValidation(EclipseKeys.defaultScalaInstallation in ref, state) |@| settingValidation(Keys.scalaVersion in ref, state)) { (options, installation, version) =>
       val ideSettings = fromScalacToSDT(options)
-      ScalaVersion.parse(version).settingsFrom(ideSettings.toMap).toSeq
+      ScalaVersion.parse(installation, version).settingsFrom(ideSettings.toMap).toSeq
     } map { options => if (options.nonEmpty) ("scala.compiler.useProjectSettings" -> "true") +: options else options }
   }
 

--- a/src/main/scala-sbt-1.0/com/typesafe/sbteclipse/core/Eclipse.scala
+++ b/src/main/scala-sbt-1.0/com/typesafe/sbteclipse/core/Eclipse.scala
@@ -436,9 +436,9 @@ private object Eclipse extends EclipseSDTConfig {
   def scalacOptions(ref: ProjectRef, state: State): Validation[Seq[(String, String)]] = {
     // Here we have to look at scalacOptions *for compilation*, vs. the ones used for testing.
     // We have to pick one set, and this should be the most complete set.
-    (evaluateTask(Keys.scalacOptions in sbt.Compile, ref, state) |@| settingValidation(EclipseKeys.defaultScalaInstallation in ref, state) |@| settingValidation(Keys.scalaVersion in ref, state)) { (options, installation, version) =>
+    (evaluateTask(Keys.scalacOptions in sbt.Compile, ref, state) |@| settingValidation(EclipseKeys.defaultScalaInstallation in ref, state) |@| settingValidation(Keys.scalaVersion in ref, state)) { (options, installationVersion, projectVersion) =>
       val ideSettings = fromScalacToSDT(options)
-      ScalaVersion.parse(installation, version).settingsFrom(ideSettings.toMap).toSeq
+      ScalaVersion.parse(installationVersion, projectVersion).settingsFrom(ideSettings.toMap).toSeq
     } map { options => if (options.nonEmpty) ("scala.compiler.useProjectSettings" -> "true") +: options else options }
   }
 

--- a/src/main/scala-sbt-1.0/com/typesafe/sbteclipse/core/EclipsePlugin.scala
+++ b/src/main/scala-sbt-1.0/com/typesafe/sbteclipse/core/EclipsePlugin.scala
@@ -50,6 +50,7 @@ object EclipsePlugin {
       preTasks := Seq(),
       skipProject := false,
       withBundledScalaContainers := projectFlavor.value.id == EclipseProjectFlavor.ScalaIDE.id,
+      defaultScalaInstallation := "2.12",
       classpathTransformerFactories := defaultClasspathTransformerFactories(withBundledScalaContainers.value),
       projectTransformerFactories := Seq(EclipseRewriteRuleTransformerFactory.Identity),
       configurations := Set(Configurations.Compile, Configurations.Test)) ++ copyManagedSettings(sbt.Compile) ++ copyManagedSettings(sbt.Test)
@@ -147,6 +148,10 @@ object EclipsePlugin {
       prefix(WithBundledScalaContainers),
       "Let the generated project use the bundled Scala library of the ScalaIDE plugin")
 
+    val defaultScalaInstallation: SettingKey[String] = SettingKey(
+      prefix(DefaultScalaInstallation),
+      """The default Scala installation configured in the ScalaIDE workspace, e.g. "2.12" for ScalaIDE 4.7.0, "2.11" for ScalaIDE 4.5.0 """)    
+      
     val useProjectId: SettingKey[Boolean] = SettingKey(
       prefix(UseProjectId),
       "Use the sbt project id as the Eclipse project name?")

--- a/src/main/scala-sbt-1.0/com/typesafe/sbteclipse/core/EclipsePlugin.scala
+++ b/src/main/scala-sbt-1.0/com/typesafe/sbteclipse/core/EclipsePlugin.scala
@@ -150,8 +150,8 @@ object EclipsePlugin {
 
     val defaultScalaInstallation: SettingKey[String] = SettingKey(
       prefix(DefaultScalaInstallation),
-      """The default Scala installation configured in the ScalaIDE workspace, e.g. "2.12" for ScalaIDE 4.7.0, "2.11" for ScalaIDE 4.5.0 """)    
-      
+      """The default Scala installation configured in the ScalaIDE workspace, e.g. "2.12" for ScalaIDE 4.7.0, "2.11" for ScalaIDE 4.5.0 """)
+
     val useProjectId: SettingKey[Boolean] = SettingKey(
       prefix(UseProjectId),
       "Use the sbt project id as the Eclipse project name?")

--- a/src/main/scala/com/typesafe/sbteclipse/core/EclipseOpts.scala
+++ b/src/main/scala/com/typesafe/sbteclipse/core/EclipseOpts.scala
@@ -31,4 +31,6 @@ private object EclipseOpts {
   val UseProjectId = "use-project-id"
 
   val WithBundledScalaContainers = "with-bundled-scala-containers"
+
+  val DefaultScalaInstallation = "default-scala-installation"
 }

--- a/src/main/scala/com/typesafe/sbteclipse/core/util/ScalaVersion.scala
+++ b/src/main/scala/com/typesafe/sbteclipse/core/util/ScalaVersion.scala
@@ -14,7 +14,7 @@ private[core] object ScalaVersion {
   private val installationRegex = """(\d+)\.(\d+)""".r
   private val versionRegex = """(\d+)\.(\d+)\.(\d+)(-\S+)?""".r
 
-  def parse(installation: String, version: String): ScalaVersion = (installation, version) match {
+  def parse(installationVersion: String, projectVersion: String): ScalaVersion = (installationVersion, projectVersion) match {
     case (installationRegex(eraDefault, majorDefault), versionRegex(era, major, minor, qualifier)) =>
       // if qualifier exists (i.e., is not null), drop the leading '-'
       val qual = Option(qualifier).map(_.tail)

--- a/src/main/scala/com/typesafe/sbteclipse/core/util/ScalaVersion.scala
+++ b/src/main/scala/com/typesafe/sbteclipse/core/util/ScalaVersion.scala
@@ -11,28 +11,30 @@ private[core] case object NoScalaVersion extends ScalaVersion {
 }
 
 private[core] object ScalaVersion {
+  private val installationRegex = """(\d+)\.(\d+)""".r
   private val versionRegex = """(\d+)\.(\d+)\.(\d+)(-\S+)?""".r
 
-  def parse(version: String): ScalaVersion = version match {
-    case versionRegex(era, major, minor, qualifier) =>
+  def parse(installation: String, version: String): ScalaVersion = (installation, version) match {
+    case (installationRegex(eraDefault, majorDefault), versionRegex(era, major, minor, qualifier)) =>
       // if qualifier exists (i.e., is not null), drop the leading '-'
       val qual = Option(qualifier).map(_.tail)
       Exception.failAsValue(classOf[NumberFormatException])(NoScalaVersion) {
-        FullScalaVersion(era.toInt, major.toInt, minor.toInt, qual)
+        FullScalaVersion(eraDefault.toInt, majorDefault.toInt, era.toInt, major.toInt, minor.toInt, qual)
       }
     case _ => NoScalaVersion
   }
 
-  private[core] case class FullScalaVersion(era: Int, major: Int, minor: Int, qualifier: Option[String]) extends ScalaVersion {
-    private def isScala210: Boolean = era == 2 && major == 10
+  private[core] case class FullScalaVersion(eraDefault: Int, majorDefault: Int, era: Int, major: Int, minor: Int, qualifier: Option[String]) extends ScalaVersion {
+    private def isLowerVersionThanInstallation: Boolean = era < eraDefault || (era == eraDefault && major < majorDefault)
 
     def settingsFrom(currentSettings: Map[String, String]): Map[String, String] = {
-      // If `version` is Scala 2.10, returns the `settings` with the required additional parameters for enabling the Scala 2.10 support in Scala IDE 4.0+.
+      // If `version` is not the `workspace installation`, returns the `settings` with the required additional parameters for enabling a lower Scala version support in Scala IDE 4.0+.
       // Otherwise, returns `settings` unchanged.
-      if (isScala210) {
+      if (isLowerVersionThanInstallation) {
         val key = "scala.compiler.additionalParams"
-        val newValue = (currentSettings.getOrElse(key, "") + " -Xsource:2.10 -Ymacro-expand:none").trim()
-        currentSettings + (key -> newValue) + ("scala.compiler.installation" -> "2.10")
+        val installation = s"$era.$major"
+        val newValue = (currentSettings.getOrElse(key, "") + s" -Xsource:$installation -Ymacro-expand:none").trim()
+        currentSettings + (key -> newValue) + ("scala.compiler.installation" -> s"$installation")
       } else currentSettings
     }
   }

--- a/src/test/scala/com/typesafe/sbteclipse/core/util/ScalaVersionSpec.scala
+++ b/src/test/scala/com/typesafe/sbteclipse/core/util/ScalaVersionSpec.scala
@@ -7,27 +7,27 @@ import ScalaVersion.FullScalaVersion
 class ScalaVersionSpec extends WordSpec with Matchers {
   "ScalaVersion" should {
     """parse Scala version "2.12.0"""" in {
-      ScalaVersion.parse("2.12.0") shouldEqual FullScalaVersion(2, 12, 0, None)
+      ScalaVersion.parse("2.12", "2.12.0") shouldEqual FullScalaVersion(2, 12, 2, 12, 0, None)
     }
 
     """parse Scala version "2.12.0-SNAPSHOT"""" in {
-      ScalaVersion.parse("2.12.0-SNAPSHOT") shouldEqual FullScalaVersion(2, 12, 0, Some("SNAPSHOT"))
+      ScalaVersion.parse("2.12", "2.12.0-SNAPSHOT") shouldEqual FullScalaVersion(2, 12, 2, 12, 0, Some("SNAPSHOT"))
     }
 
     """parse Scala version "2.12.0-RC10"""" in {
-      ScalaVersion.parse("2.12.0-RC10") shouldEqual FullScalaVersion(2, 12, 0, Some("RC10"))
+      ScalaVersion.parse("2.12", "2.12.0-RC10") shouldEqual FullScalaVersion(2, 12, 2, 12, 0, Some("RC10"))
     }
 
     """parse Scala version "2.12.0-M1"""" in {
-      ScalaVersion.parse("2.12.0-M1") shouldEqual FullScalaVersion(2, 12, 0, Some("M1"))
+      ScalaVersion.parse("2.12", "2.12.0-M1") shouldEqual FullScalaVersion(2, 12, 2, 12, 0, Some("M1"))
     }
 
     """parse Scala version "2.12.0-51e77037f2adc4ffa7421aa36803a5874292b70d"""" in {
-      ScalaVersion.parse("2.12.0-51e77037f2adc4ffa7421aa36803a5874292b70d") shouldEqual FullScalaVersion(2, 12, 0, Some("51e77037f2adc4ffa7421aa36803a5874292b70d"))
+      ScalaVersion.parse("2.12", "2.12.0-51e77037f2adc4ffa7421aa36803a5874292b70d") shouldEqual FullScalaVersion(2, 12, 2, 12, 0, Some("51e77037f2adc4ffa7421aa36803a5874292b70d"))
     }
 
     """fail to parse "2.12"""" in {
-      ScalaVersion.parse("2.12") shouldEqual NoScalaVersion
+      ScalaVersion.parse("2.12", "2.12") shouldEqual NoScalaVersion
     }
   }
 }


### PR DESCRIPTION
improved-support-for-multiple-scala-versions
for ScalaIDE-4.6 and up
to support also scala-2.11 while preserving functionality for older versions,
i.e. support for  scala-2.10 in ScalaIDE-4.0 and up.

This is a patch on top of commit 1bbf64c0cf8a9942afb56bcd228179d1019f0b9e (Fix #239)
added EclipseKeys.defaultScalaInstallation
usage documentation added in README.md